### PR TITLE
fix for datetime with subsecond precision

### DIFF
--- a/gpspoint.cpp
+++ b/gpspoint.cpp
@@ -11,12 +11,10 @@ GpsPoint::GpsPoint() {
 }
 
 void GpsPoint::setTime(QString time_str) {
-    QRegExp rx("(\\d\\d\\d\\d-\\d\\d-\\d\\d)T(\\d\\d:\\d\\d:\\d\\d)Z");
-    rx.indexIn(time_str, 0);
-
-    dateTime->setDate(QDate::fromString(rx.cap(1), "yyyy-MM-dd"));
-    dateTime->setTime(QTime::fromString(rx.cap(2), "hh:mm:ss"));
-
+    QDateTime dt = QDateTime::fromString(time_str, Qt::ISODate);
+    if(dt.isValid()) {
+        *dateTime = dt;
+    }
 }
 
 void GpsPoint::changeDateTime(int year, int month, int day, int seconds) {

--- a/gpspoint.h
+++ b/gpspoint.h
@@ -5,7 +5,6 @@
 #ifndef GPSPOINT_H
 #define GPSPOINT_H
 #include<QString>
-#include<QRegExp>
 #include <QDateTime>
 
 class GpsPoint


### PR DESCRIPTION
Found bug with gps log recorded by https://github.com/mendhak/gpslogger
log sample:
```<trkpt lat="20.5036473" lon="-87.2206334"><ele>-6.099999904632568</ele><time>2021-09-14T05:06:41.537Z</time><src>network</src></trkpt>```
Datetime (for example, `2021-09-14T05:06:41.537Z`) doesn't match regex `(\d\d\d\d-\d\d-\d\d)T(\d\d:\d\d:\d\d)Z` because of miliseconds precision.
Moving to qt datetime parser fix this