### PR TITLE
Fix Qt6 QString::arg() incompatibility with QFlags<Qt::KeyboardModifier>

### DIFF
--- a/mapwidget.cpp
+++ b/mapwidget.cpp
@@ -423,7 +423,7 @@ void MapWidget::markerSelected(int id, bool isSelected)
 void MapWidget::markerClicked(int id)
 {
     QStringList scriptStr;
-    scriptStr << QString("markerOrObjectClicked(%1, %2);").arg(id).arg((QApplication::keyboardModifiers() & Qt::ControlModifier));
+    scriptStr << QString("markerOrObjectClicked(%1, %2);").arg(id).arg(int(QApplication::keyboardModifiers() & Qt::ControlModifier));
 
     mapView->page()->runJavaScript(scriptStr.join("\n"), [](const QVariant& result) { qDebug() << result.toString(); });
     emit mClicked(id, 0, 1);
@@ -459,7 +459,7 @@ void MapWidget::objectSelected(int id, bool isSelected)
 void MapWidget::objectClicked(int id)
 {
     QStringList scriptStr;
-    scriptStr << QString("markerOrObjectClicked(%1, %2);").arg(id).arg((QApplication::keyboardModifiers() & Qt::ControlModifier));
+    scriptStr << QString("markerOrObjectClicked(%1, %2);").arg(id).arg(int(QApplication::keyboardModifiers() & Qt::ControlModifier));
 
     mapView->page()->runJavaScript(scriptStr.join("\n"), [](const QVariant& result) { qDebug() << result.toString(); });
     emit oClicked(id, 0, 1);


### PR DESCRIPTION
Cast the result of keyboard modifier check to int before passing to QString::arg(). This fixes compilation errors in markerClicked() and objectClicked() methods.

Fixes: error: no matching function for call to 'QString::arg(QFlags<Qt::KeyboardModifier>)'